### PR TITLE
Update base-image-url-gui

### DIFF
--- a/.github/workflows/build_img_gui.yml
+++ b/.github/workflows/build_img_gui.yml
@@ -52,7 +52,7 @@ jobs:
           CONSTRAINTS: "https://github.com/OpenVoiceOS/ovos-releases/raw/refs/heads/main/constraints-alpha.txt"
           MYCROFT_CONFIG_FILES: "mycroft.conf,mycroft_gui.conf"
         with:
-          base-image-url: 
+          base-image-url: https://github.com/andlo/raspOVOS/releases/download/raspOVOS-bookworm-arm64-lite-2024-12-22/raspOVOS-bookworm-arm64-lite.img.xz
           image-path: raspOVOS-GUI-bookworm-arm64-lite.img
           compress-with-xz: true
           shrink: true


### PR DESCRIPTION
This PR updates the base-image-url in `build_img_gui.yml` to reflect the latest release.