### PR TITLE
Update base-image-url-nl

### DIFF
--- a/.github/workflows/build_img_nl.yml
+++ b/.github/workflows/build_img_nl.yml
@@ -53,7 +53,7 @@ jobs:
           CONSTRAINTS: "https://github.com/OpenVoiceOS/ovos-releases/raw/refs/heads/main/constraints-alpha.txt"
           MYCROFT_CONFIG_FILES: "mycroft.conf,mycroft_nl.conf"
         with:
-          base-image-url: 
+          base-image-url: https://github.com/andlo/raspOVOS/releases/download/raspOVOS-bookworm-arm64-lite-2024-12-22/raspOVOS-bookworm-arm64-lite.img.xz
           image-path: raspOVOS-dutch-bookworm-arm64-lite.img
           compress-with-xz: true
           shrink: true


### PR DESCRIPTION
This PR updates the base-image-url in `build_img_nl.yml` to reflect the latest release.